### PR TITLE
Accept only a single file as grammar

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2,7 +2,7 @@ load("@rules_tree_sitter//tree_sitter:tree_sitter.bzl", "tree_sitter_cc_library"
 
 tree_sitter_cc_library(
     name = "hello",
-    grammar = ["hello.js"],
+    grammar = "hello.js",
 )
 
 cc_test(

--- a/tree_sitter/tree_sitter.bzl
+++ b/tree_sitter/tree_sitter.bzl
@@ -49,7 +49,7 @@ def _tree_sitter_common(ctx):
         outputs = outputs,
         command = _TREE_SITTER_LIBRARY.format(
             tree_sitter = toolchain.tree_sitter_tool.executable.path,
-            grammar = ctx.files.grammar[0].path,
+            grammar = ctx.file.grammar.path,
             node_types_json = node_types_json.path if node_types_json != None else "",
             parser_c = parser_c.path,
             parser_h = parser_h.path,
@@ -121,7 +121,7 @@ def _tree_sitter_cc_library(ctx):
 tree_sitter_cc_library = rule(
     _tree_sitter_cc_library,
     attrs = {
-        "grammar": attr.label_list(mandatory = True, allow_files = True),
+        "grammar": attr.label(mandatory = True, allow_single_file = True),
         "srcs": attr.label_list(allow_files = True),
         "node_types": attr.output(
             doc = "The name for the node-types.json file",


### PR DESCRIPTION
This might have been the intention considering that only the first element of the label_list is used and the README doesn't have the `[]`:
https://github.com/elliottt/rules_tree_sitter/blob/8e248d1ea054b0d5ecdd71de3dccfe421354491f/README.md?plain=1#L35-L38

The alternative is that the README is wrong and needs to say `grammar = ["grammar.js"]`.