### PR TITLE
Update tree-sitter to 0.20.8 and add arm64 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ http_archive(
 
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 node_repositories(
-    node_version = "10.19.0",
+    node_version = "16.9.1",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,15 +21,12 @@ http_archive(
 )
 
 http_archive(
-    name = "rules_nodejs",
-    sha256 = "d124665ea12f89153086746821cf6c9ef93ab88360a50c1aeefa1fe522421704",
-    strip_prefix = "rules_nodejs-6.0.0-beta1",
-    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.0.0-beta1/rules_nodejs-v6.0.0-beta1.tar.gz",
+    name = "build_bazel_rules_nodejs",
+    sha256 = "4e1a5633267a0ca1d550cced2919dd4148575c0bafd47608b88aea79c41b5ca3",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.2.0/rules_nodejs-4.2.0.tar.gz"],
 )
 
-load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
-
-nodejs_register_toolchains(
-    name = "nodejs",
-    node_version = DEFAULT_NODE_VERSION,
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+node_repositories(
+    node_version = "16.9.1",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,12 +22,15 @@ http_archive(
 )
 
 http_archive(
-    name = "build_bazel_rules_nodejs",
-    sha256 = "4e1a5633267a0ca1d550cced2919dd4148575c0bafd47608b88aea79c41b5ca3",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.2.0/rules_nodejs-4.2.0.tar.gz"],
+    name = "rules_nodejs",
+    sha256 = "d124665ea12f89153086746821cf6c9ef93ab88360a50c1aeefa1fe522421704",
+    strip_prefix = "rules_nodejs-6.0.0-beta1",
+    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.0.0-beta1/rules_nodejs-v6.0.0-beta1.tar.gz",
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
-node_repositories(
-    node_version = "10.19.0",
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "nodejs",
+    node_version = DEFAULT_NODE_VERSION,
 )

--- a/tree_sitter/internal/repository.bzl
+++ b/tree_sitter/internal/repository.bzl
@@ -68,7 +68,9 @@ tree_sitter_binary = rule(
 
 TOOL_PLATFORMS = {
     "tree-sitter-linux-x64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    "tree-sitter-linux-arm64": ["@platforms//os:linux", "@platforms//cpu:aarch64"],
     "tree-sitter-macos-x64": ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+    "tree-sitter-macos-arm64": ["@platforms//os:macos", "@platforms//cpu:aarch64"],
 }
 
 def _tree_sitter_repository(ctx):

--- a/tree_sitter/internal/toolchain.bzl
+++ b/tree_sitter/internal/toolchain.bzl
@@ -107,5 +107,4 @@ def declare_toolchains():
                 toolchain = toolchain,
                 toolchain_type = TREE_SITTER_TOOLCHAIN_TYPE,
                 exec_compatible_with = platforms,
-                target_compatible_with = platforms,
             )

--- a/tree_sitter/internal/toolchain.bzl
+++ b/tree_sitter/internal/toolchain.bzl
@@ -95,7 +95,8 @@ def setup_tree_sitter_toolchains():
 def declare_toolchains():
     for version in VERSION_SHA256:
         for key in VERSION_SHA256[version]:
-            if None == TOOL_PLATFORMS.get(key, None):
+            platforms = TOOL_PLATFORMS.get(key, None)
+            if platforms == None:
                 continue
 
             name = _toolchain_name(key, version)
@@ -105,4 +106,6 @@ def declare_toolchains():
                 name = name,
                 toolchain = toolchain,
                 toolchain_type = TREE_SITTER_TOOLCHAIN_TYPE,
+                exec_compatible_with = platforms,
+                target_compatible_with = platforms,
             )

--- a/tree_sitter/internal/versions.bzl
+++ b/tree_sitter/internal/versions.bzl
@@ -1,11 +1,13 @@
 
-DEFAULT_VERSION = "0.20.6"
+DEFAULT_VERSION = "0.20.8"
 
 VERSION_SHA256 = {
-    "0.20.6": {
-        "tree-sitter-linux-x64": "f7001a0ff42cb27c0b0a9023352b31273e98f6c72282003c6bd1fe9ec1018491",
-        "tree-sitter-macos-x64": "3719822cbb27ed4e2132a28a9740803b151fc7aa4597986bc0bd51f3a0b8ff1e",
-        "source-code": "4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de",
+    "0.20.8": {
+        "tree-sitter-linux-x64": "90734a35cebd1aa4c0a5f7cbe81063724576f489951e5b55f88dcf073057d100",
+        "tree-sitter-linux-arm64": "51a50f907f71157003ace392c0bb1c0e8fee2973834e8ee1622da0ac2bb9bffc",
+        "tree-sitter-macos-x64": "90e59681b60b15d28b01b3560d2e0e262eacf5efca16990c0fb814c661d992d9",
+        "tree-sitter-macos-arm64": "e443779655ed3422d7331089e3fdc3c4be662c271353634a30115ba669bf2c0f",
+        "source-code": "6181ede0b7470bfca37e293e7d5dc1d16469b9485d13f13a605baec4a8b1f791",
     }
 }
 

--- a/tree_sitter/tree_sitter.bzl
+++ b/tree_sitter/tree_sitter.bzl
@@ -81,6 +81,7 @@ def _cc_library(ctx, result):
         feature_configuration = cc_feature_configuration,
         srcs = [result.outputs.parser_c] + ctx.files.srcs,
         private_hdrs = [result.outputs.parser_h],
+        user_compile_flags = ["-Wno-unused-but-set-variable"],
         compilation_contexts = [result.toolchain.tree_sitter_lib.compilation_context],
     )
 

--- a/tree_sitter/tree_sitter.bzl
+++ b/tree_sitter/tree_sitter.bzl
@@ -131,7 +131,7 @@ tree_sitter_cc_library = rule(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
         ),
         "_node_bin": attr.label(
-            default = "@build_bazel_rules_nodejs//toolchains/node:node_bin",
+            default = "@nodejs//:node",
             allow_single_file = True,
         ),
     },

--- a/tree_sitter/tree_sitter.bzl
+++ b/tree_sitter/tree_sitter.bzl
@@ -81,7 +81,6 @@ def _cc_library(ctx, result):
         feature_configuration = cc_feature_configuration,
         srcs = [result.outputs.parser_c] + ctx.files.srcs,
         private_hdrs = [result.outputs.parser_h],
-        user_compile_flags = ["-Wno-unused-but-set-variable"],
         compilation_contexts = [result.toolchain.tree_sitter_lib.compilation_context],
     )
 
@@ -132,7 +131,7 @@ tree_sitter_cc_library = rule(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
         ),
         "_node_bin": attr.label(
-            default = "@nodejs//:node",
+            default = "@build_bazel_rules_nodejs//toolchains/node:node_bin",
             allow_single_file = True,
         ),
     },


### PR DESCRIPTION
This is a continuation of https://github.com/elliottt/rules_tree_sitter/pull/5 with a few changes:
- reverted an update to ruiles_nodejs. It seems a bit more involved than just changing a number, in particular it now depends on skylib. We can update rules_nodejs separately.
- `node_version` is now 16.9.1 which is the highest available on the 4.2.0 branch of rules_nodejs https://github.com/bazelbuild/rules_nodejs/blob/4.2.0/nodejs/private/node_versions.bzl#L1694. A version of at least 16.0.0 is needed, because that's when nodejs started including darwin-arm64 builds
- removed `user_compile_flags = ["-Wno-unused-but-set-variable"]`. It seems that the issue was fixed in the commit https://github.com/tree-sitter/tree-sitter/commit/465ceead0faf3a0aab311806795664a2c2fad5de which is included in v0.20.8 
- removed `target_compatible_with = platforms`. There's no need to restrict the toolchain like that, `exec_compatible_with` is enough.